### PR TITLE
feat(Agent): Lifecycle methods added to the prism agent

### DIFF
--- a/prism-agent/src/allButJSMain/kotlin/io.iohk.atala.prism.walletsdk.prismagent/PrismAgent.kt
+++ b/prism-agent/src/allButJSMain/kotlin/io.iohk.atala.prism.walletsdk.prismagent/PrismAgent.kt
@@ -24,7 +24,6 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpMethod
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -32,10 +31,10 @@ import kotlinx.serialization.json.JsonObject
 
 class PrismAgent {
     enum class State {
-        STOPED, STARTING, RUNNING, STOPING
+        STOPPED, STARTING, RUNNING, STOPPING
     }
 
-    var state: State = State.STOPED
+    var state: State = State.STOPPED
         private set
     val seed: Seed
     val apollo: Apollo
@@ -108,7 +107,7 @@ class PrismAgent {
 
     @Throws()
     suspend fun start() {
-        if (state != State.STOPED) {
+        if (state != State.STOPPED) {
             return
         }
         state = State.STARTING
@@ -132,6 +131,14 @@ class PrismAgent {
         } else {
             throw PrismAgentError.mediationRequestFailedError()
         }
+    }
+
+    suspend fun stop() {
+        if (state != State.RUNNING) {
+            return
+        }
+        // TODO: Revise if we need to create a cancellable for an open connection.
+        state = State.STOPPED
     }
 
     suspend fun createNewPrismDID(

--- a/prism-agent/src/allButJSTest/kotlin/io.iohk.atala.prism.walletsdk.prismagent/MediationHandlerMock.kt
+++ b/prism-agent/src/allButJSTest/kotlin/io.iohk.atala.prism.walletsdk.prismagent/MediationHandlerMock.kt
@@ -1,5 +1,6 @@
 package io.iohk.atala.prism.walletsdk.prismagent
 
+import io.iohk.atala.prism.apollo.uuid.UUID
 import io.iohk.atala.prism.walletsdk.domain.models.DID
 import io.iohk.atala.prism.walletsdk.domain.models.Mediator
 import io.iohk.atala.prism.walletsdk.domain.models.Message
@@ -19,6 +20,9 @@ class MediationHandlerMock(
 
     @Throws()
     override suspend fun bootRegisteredMediator(): Mediator? {
+        val hostDID = DID("did", "test", "123")
+        val routingDID = DID("did", "test", "123")
+        bootMediatorResponse = Mediator(UUID.randomUUID4().toString(), mediatorDID, hostDID, routingDID)
         mediator = bootMediatorResponse
         return bootMediatorResponse
     }
@@ -30,7 +34,8 @@ class MediationHandlerMock(
     }
 
     @Throws()
-    override suspend fun updateKeyListWithDIDs(dids: Array<DID>) {}
+    override suspend fun updateKeyListWithDIDs(dids: Array<DID>) {
+    }
 
     @Throws()
     override fun pickupUnreadMessages(limit: Int): Flow<Array<Pair<String, Message>>> {
@@ -38,5 +43,6 @@ class MediationHandlerMock(
     }
 
     @Throws()
-    override suspend fun registerMessagesAsRead(ids: Array<String>) {}
+    override suspend fun registerMessagesAsRead(ids: Array<String>) {
+    }
 }

--- a/prism-agent/src/allButJSTest/kotlin/io.iohk.atala.prism.walletsdk.prismagent/PrismAgentTests.kt
+++ b/prism-agent/src/allButJSTest/kotlin/io.iohk.atala.prism.walletsdk.prismagent/PrismAgentTests.kt
@@ -265,4 +265,35 @@ class PrismAgentTests {
             agent.parseInvitation(invitationString.trim())
         }
     }
+
+    @Test
+    fun testStartPrismAgent_whenCalled_thenStatusIsRunning() = runTest {
+        val agent = PrismAgent(
+            apollo = apolloMock,
+            castor = castorMock,
+            pluto = plutoMock,
+            mercury = mercuryMock,
+            connectionManager = connectionManager,
+            seed = null,
+            api = null,
+        )
+        assertEquals(PrismAgent.State.STOPPED, agent.state)
+        agent.start()
+        assertEquals(PrismAgent.State.RUNNING, agent.state)
+    }
+
+    @Test
+    fun testStopPrismAgent_whenCalled_thenStatusIsStopped() = runTest {
+        val agent = PrismAgent(
+            apollo = apolloMock,
+            castor = castorMock,
+            pluto = plutoMock,
+            mercury = mercuryMock,
+            connectionManager = connectionManager,
+            seed = null,
+            api = null,
+        )
+        agent.stop()
+        assertEquals(PrismAgent.State.STOPPED, agent.state)
+    }
 }


### PR DESCRIPTION
[ATL-2996] Add lifecycle management to the prism agent

[ATL-2996]: https://input-output.atlassian.net/browse/ATL-2996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ