### PR TITLE
feat: Implement ED25519 - Keypair generation

### DIFF
--- a/atala-prism-sdk/src/androidMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/Ed25519.kt
+++ b/atala-prism-sdk/src/androidMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/Ed25519.kt
@@ -4,9 +4,11 @@ import io.iohk.atala.prism.walletsdk.domain.models.Curve
 import io.iohk.atala.prism.walletsdk.domain.models.KeyCurve
 import io.iohk.atala.prism.walletsdk.domain.models.PrivateKey
 import io.iohk.atala.prism.walletsdk.domain.models.PublicKey
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.security.KeyPair
-import java.security.KeyPairGenerator
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import java.security.SecureRandom
 import io.iohk.atala.prism.walletsdk.domain.models.KeyPair as KeyPairModel
 
 /**
@@ -14,18 +16,19 @@ import io.iohk.atala.prism.walletsdk.domain.models.KeyPair as KeyPairModel
  */
 actual object Ed25519 {
     actual fun createKeyPair(): KeyPairModel {
-        val provider = BouncyCastleProvider()
-        val generator = KeyPairGenerator.getInstance("Ed25519", provider)
-        val javaKeyPair: KeyPair = generator.generateKeyPair()
+        val generator = Ed25519KeyPairGenerator()
+        generator.init(Ed25519KeyGenerationParameters(SecureRandom()))
+        val keyPair = generator.generateKeyPair()
+
         return KeyPairModel(
             KeyCurve(Curve.ED25519),
             PrivateKey(
                 KeyCurve(Curve.ED25519),
-                javaKeyPair.private.encoded
+                (keyPair.private as Ed25519PrivateKeyParameters).encoded
             ),
             PublicKey(
                 KeyCurve(Curve.ED25519),
-                javaKeyPair.public.encoded
+                (keyPair.public as Ed25519PublicKeyParameters).encoded
             )
         )
     }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloImpl.kt
@@ -48,10 +48,13 @@ class ApolloImpl : Apollo {
         )
     }
 
-    override fun createKeyPair(seed: Seed, curve: KeyCurve): KeyPair {
+    override fun createKeyPair(seed: Seed?, curve: KeyCurve): KeyPair {
         return when (curve.curve) {
             Curve.SECP256K1 -> {
                 val derivationPath = DerivationPath.fromPath("m/${curve.index}'/0'/0'")
+                if (seed == null) {
+                    throw ApolloError.InvalidMnemonicWord()
+                }
                 val extendedKey = KeyDerivation.deriveKey(seed.value, derivationPath)
                 val kmmKeyPair = extendedKey.keyPair()
                 val privateKey = kmmKeyPair.privateKey as KMMECSecp256k1PrivateKey
@@ -68,19 +71,24 @@ class ApolloImpl : Apollo {
                     ),
                 )
             }
+
             Curve.ED25519 -> {
                 Ed25519.createKeyPair()
             }
+
             Curve.X25519 -> {
                 X25519.createKeyPair()
             }
         }
     }
 
-    override fun createKeyPair(seed: Seed, privateKey: PrivateKey): KeyPair {
+    override fun createKeyPair(seed: Seed?, privateKey: PrivateKey): KeyPair {
         return when (privateKey.keyCurve.curve) {
             Curve.SECP256K1 -> {
                 val derivationPath = DerivationPath.fromPath("m/${privateKey.keyCurve.index}'/0'/0'")
+                if (seed == null) {
+                    throw ApolloError.InvalidMnemonicWord()
+                }
                 val extendedKey = KeyDerivation.deriveKey(seed.value, derivationPath)
                 val kmmKeyPair = extendedKey.keyPair()
                 val mPrivateKey = kmmKeyPair.privateKey as KMMECSecp256k1PrivateKey
@@ -97,8 +105,14 @@ class ApolloImpl : Apollo {
                     ),
                 )
             }
-            Curve.ED25519 -> TODO()
-            Curve.X25519 -> TODO()
+
+            Curve.ED25519 -> {
+                Ed25519.createKeyPair()
+            }
+
+            Curve.X25519 -> {
+                X25519.createKeyPair()
+            }
         }
     }
 
@@ -133,6 +147,7 @@ class ApolloImpl : Apollo {
                     value = kmmPublicKey.getEncoded(),
                 )
             }
+
             else -> {
                 // Only SECP256K1 can be initialised by using byte Coordinates for EC Curve
                 throw ApolloError.InvalidKeyCurve()
@@ -149,6 +164,7 @@ class ApolloImpl : Apollo {
                     value = kmmPublicKey.getEncoded(),
                 )
             }
+
             else -> {
                 // Other type of keys are initialised using a ByteArray, for now we just support SECP256K1
                 TODO()
@@ -169,6 +185,7 @@ class ApolloImpl : Apollo {
                     value = kmmSignature,
                 )
             }
+
             else -> {
                 TODO()
             }
@@ -180,6 +197,7 @@ class ApolloImpl : Apollo {
             Curve.SECP256K1 -> {
                 signMessage(privateKey, message.encodeToByteArray())
             }
+
             else -> {
                 TODO()
             }
@@ -197,6 +215,7 @@ class ApolloImpl : Apollo {
                     signature = signature.value,
                 )
             }
+
             else -> {
                 TODO()
             }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Apollo.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Apollo.kt
@@ -18,10 +18,10 @@ interface Apollo {
     fun createRandomSeed(passphrase: String? = ""): SeedWords
 
     // @JsName("createKeyPairFromKeyCurve")
-    fun createKeyPair(seed: Seed, curve: KeyCurve): KeyPair
+    fun createKeyPair(seed: Seed? = null, curve: KeyCurve): KeyPair
 
     // @JsName("createKeyPairFromPrivateKey")
-    fun createKeyPair(seed: Seed, privateKey: PrivateKey): KeyPair
+    fun createKeyPair(seed: Seed? = null, privateKey: PrivateKey): KeyPair
 
     // @JsName("compressedPublicKeyFromPublicKey")
     fun compressedPublicKey(publicKey: PublicKey): CompressedPublicKey

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
@@ -98,4 +98,13 @@ class ApolloTests {
 
         assertTrue(apollo.verifySignature(keyPair.publicKey, text.encodeToByteArray(), signature))
     }
+
+    @Test
+    fun testCreateKeyPair_whenNoSeedAndKeyCurveEd25519_thenPrivateKeyLengthIsCorrect() {
+        val keyPair = apollo.createKeyPair(curve = KeyCurve(Curve.ED25519))
+        val privateKey = keyPair.privateKey
+        val publicKey = keyPair.publicKey
+        assertEquals(32, privateKey.value.size)
+        assertEquals(32, publicKey.value.size)
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/castor/ApolloMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/castor/ApolloMock.kt
@@ -43,11 +43,11 @@ class ApolloMock : Apollo {
         return createRandomSeedReturn
     }
 
-    override fun createKeyPair(seed: Seed, curve: KeyCurve): KeyPair {
+    override fun createKeyPair(seed: Seed?, curve: KeyCurve): KeyPair {
         return createKeyPairReturn
     }
 
-    override fun createKeyPair(seed: Seed, privateKey: PrivateKey): KeyPair {
+    override fun createKeyPair(seed: Seed?, privateKey: PrivateKey): KeyPair {
         return createKeyPairReturn
     }
 

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ApolloMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ApolloMock.kt
@@ -43,11 +43,11 @@ class ApolloMock : Apollo {
         return createRandomSeedReturn
     }
 
-    override fun createKeyPair(seed: Seed, curve: KeyCurve): KeyPair {
+    override fun createKeyPair(seed: Seed?, curve: KeyCurve): KeyPair {
         return createKeyPairReturn
     }
 
-    override fun createKeyPair(seed: Seed, privateKey: PrivateKey): KeyPair {
+    override fun createKeyPair(seed: Seed?, privateKey: PrivateKey): KeyPair {
         return createKeyPairReturn
     }
 

--- a/atala-prism-sdk/src/jvmMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/Ed25519.kt
+++ b/atala-prism-sdk/src/jvmMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/Ed25519.kt
@@ -4,9 +4,11 @@ import io.iohk.atala.prism.walletsdk.domain.models.Curve
 import io.iohk.atala.prism.walletsdk.domain.models.KeyCurve
 import io.iohk.atala.prism.walletsdk.domain.models.PrivateKey
 import io.iohk.atala.prism.walletsdk.domain.models.PublicKey
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.security.KeyPair
-import java.security.KeyPairGenerator
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import java.security.SecureRandom
 import io.iohk.atala.prism.walletsdk.domain.models.KeyPair as KeyPairModel
 
 /**
@@ -14,18 +16,19 @@ import io.iohk.atala.prism.walletsdk.domain.models.KeyPair as KeyPairModel
  */
 actual object Ed25519 {
     actual fun createKeyPair(): KeyPairModel {
-        val provider = BouncyCastleProvider()
-        val generator = KeyPairGenerator.getInstance("Ed25519", provider)
-        val javaKeyPair: KeyPair = generator.generateKeyPair()
+        val generator = Ed25519KeyPairGenerator()
+        generator.init(Ed25519KeyGenerationParameters(SecureRandom()))
+        val keyPair = generator.generateKeyPair()
+
         return KeyPairModel(
             KeyCurve(Curve.ED25519),
             PrivateKey(
                 KeyCurve(Curve.ED25519),
-                javaKeyPair.private.encoded
+                (keyPair.private as Ed25519PrivateKeyParameters).encoded
             ),
             PublicKey(
                 KeyCurve(Curve.ED25519),
-                javaKeyPair.public.encoded
+                (keyPair.public as Ed25519PublicKeyParameters).encoded
             )
         )
     }


### PR DESCRIPTION
Replace the java keypair generation with the `BouncyCastle` `ED25519KeyPairGenerator`. We did this to avoid the PKCS8 encoded keys, this assures the keys are 32 bytes long.