### PR TITLE
fix: Implement test for key pair creation using mnemonics and seed for curve SECP256K1

### DIFF
--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
@@ -1,5 +1,6 @@
 package io.iohk.atala.prism.walletsdk.apollo
 
+import io.iohk.atala.prism.apollo.base64.base64UrlEncoded
 import io.iohk.atala.prism.apollo.derivation.MnemonicChecksumException
 import io.iohk.atala.prism.apollo.derivation.MnemonicLengthException
 import io.iohk.atala.prism.apollo.utils.ECConfig
@@ -115,5 +116,16 @@ class ApolloTests {
         val publicKey = keyPair.publicKey
         assertEquals(32, privateKey.value.size)
         assertEquals(32, publicKey.value.size)
+    }
+
+    @Test
+    fun testCreateKeyPair_whenUsingSeedAndMnemonics_thenKeyPairIsCorrect() {
+        val mnemonics = arrayOf("blade", "multiply", "coil", "rare", "fox", "doll", "tongue", "please", "icon", "mind", "gesture", "moral", "old", "laugh", "symptom", "assume", "burden", "appear", "always", "oil", "ticket", "vault", "return", "height")
+        val seed = apollo.createSeed(mnemonics, "")
+
+        val expectedPrivateKeyBase64Url = "xURclKhT6as1Tb9vg4AJRRLPAMWb9dYTTthDvXEKjMc"
+
+        val keyPair = apollo.createKeyPair(seed, KeyCurve(Curve.SECP256K1))
+        assertEquals(expectedPrivateKeyBase64Url, keyPair.privateKey.value.base64UrlEncoded)
     }
 }


### PR DESCRIPTION
We included a new test to verify key pair creation from a mnemonic and seed using curve SECP256K1. The test verifies that the private key encoded into base64url is the expected.