### PR TITLE
fix: credentials duplicated when stored locally

### DIFF
--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
@@ -201,7 +201,7 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
     override fun storeCredential(credential: VerifiableCredential) {
         getInstance().verifiableCredentialQueries.insert(
             VerifiableCredentialDB(
-                UUID.randomUUID4().toString(),
+                credential.id,
                 credential.credentialType.type,
                 credential.expirationDate,
                 credential.issuanceDate,

--- a/atala-prism-sdk/src/commonMain/sqldelight/io.iohk.atala.prism.walletsdk.pluto/data/VerifiableCredential.sq
+++ b/atala-prism-sdk/src/commonMain/sqldelight/io.iohk.atala.prism.walletsdk.pluto/data/VerifiableCredential.sq
@@ -9,7 +9,7 @@ CREATE TABLE VerifiableCredential (
 );
 
 insert:
-INSERT INTO VerifiableCredential(id, credentialType, expirationDate, issuanceDate, verifiableCredentialJson, issuerDIDId)
+INSERT OR IGNORE INTO VerifiableCredential(id, credentialType, expirationDate, issuanceDate, verifiableCredentialJson, issuerDIDId)
 VALUES ?;
 
 fetchAllCredentials:


### PR DESCRIPTION
The current query to store credentials locally was using the wrong ID making the storing process miss the verification if the credential already existed.