### PR TITLE
fix: message model id generates a duplicity issue

### DIFF
--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
@@ -112,7 +112,7 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
     override fun storeMessage(message: Message) {
         getInstance().messageQueries.insert(
             MessageDB(
-                UUID.randomUUID4().toString(),
+                message.id,
                 message.createdTime,
                 message.toJsonString(),
                 message.from.toString(),

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/IssueCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/IssueCredential.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.Json
 
 @Serializable
 data class IssueCredential(
-    val id: String? = UUID.randomUUID4().toString(),
+    val id: String = UUID.randomUUID4().toString(),
     val body: Body,
     val attachments: Array<AttachmentDescriptor>,
     val thid: String?,
@@ -31,7 +31,7 @@ data class IssueCredential(
 
     fun makeMessage(): Message {
         return Message(
-            id = id ?: UUID.randomUUID4().toString(),
+            id = id,
             piuri = type,
             from = from,
             to = to,

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/OfferCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/OfferCredential.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.Json
  */
 @Serializable
 data class OfferCredential @JvmOverloads constructor(
-    val id: String? = UUID.randomUUID4().toString(),
+    val id: String = UUID.randomUUID4().toString(),
     val body: Body,
     val attachments: Array<AttachmentDescriptor>,
     val thid: String?,
@@ -34,7 +34,7 @@ data class OfferCredential @JvmOverloads constructor(
 
     fun makeMessage(): Message {
         return Message(
-            id = id ?: UUID.randomUUID4().toString(),
+            id = id,
             piuri = type,
             from = from,
             to = to,

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/ProposeCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/ProposeCredential.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.Json
  */
 @Serializable
 data class ProposeCredential @JvmOverloads constructor(
-    val id: String? = UUID.randomUUID4().toString(),
+    val id: String = UUID.randomUUID4().toString(),
     val body: Body,
     val attachments: Array<AttachmentDescriptor>,
     val thid: String?,
@@ -29,7 +29,7 @@ data class ProposeCredential @JvmOverloads constructor(
 
     fun makeMessage(): Message {
         return Message(
-            id = id ?: UUID.randomUUID4().toString(),
+            id = id,
             piuri = type,
             from = from,
             to = to,

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/RequestCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/issueCredential/RequestCredential.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.Json
  */
 @Serializable
 data class RequestCredential @JvmOverloads constructor(
-    val id: String? = UUID.randomUUID4().toString(),
+    val id: String = UUID.randomUUID4().toString(),
     val body: Body,
     val attachments: Array<AttachmentDescriptor>,
     val thid: String?,
@@ -29,7 +29,7 @@ data class RequestCredential @JvmOverloads constructor(
 
     fun makeMessage(): Message {
         return Message(
-            id = id ?: UUID.randomUUID4().toString(),
+            id = id,
             piuri = type,
             from = from,
             to = to,

--- a/atala-prism-sdk/src/commonMain/sqldelight/io.iohk.atala.prism.walletsdk.pluto/data/Message.sq
+++ b/atala-prism-sdk/src/commonMain/sqldelight/io.iohk.atala.prism.walletsdk.pluto/data/Message.sq
@@ -11,7 +11,7 @@ CREATE TABLE Message (
 );
 
 insert:
-INSERT INTO Message(id, createdTime, dataJson, `from`, thid, `to`, type, isReceived)
+INSERT OR IGNORE INTO Message(id, createdTime, dataJson, `from`, thid, `to`, type, isReceived)
 VALUES ?;
 
 fetchAllMessages:


### PR DESCRIPTION
The message model on the SDK overrides the message id with a random UUID, that breaks the `UNIQUE` rule pluto has to store the messages. This lead to discover that the mediator keeps sending back all the messages even after marked as picked up.
With this PR the UI does not sees the duplicity issue and the mediator will get fixed in the near future.