### PR TITLE
refactor: Change usage from Mnemonic to MnemonicHelper from Apollo

### DIFF
--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloImpl.kt
@@ -1,7 +1,7 @@
 package io.iohk.atala.prism.walletsdk.apollo
 
 import io.iohk.atala.prism.apollo.derivation.HDKey
-import io.iohk.atala.prism.apollo.derivation.Mnemonic
+import io.iohk.atala.prism.apollo.derivation.MnemonicHelper
 import io.iohk.atala.prism.apollo.derivation.MnemonicLengthException
 import io.iohk.atala.prism.walletsdk.apollo.helpers.BytesOps
 import io.iohk.atala.prism.walletsdk.apollo.utils.Ed25519KeyPair
@@ -39,7 +39,7 @@ class ApolloImpl : Apollo {
      * @return An array of mnemonic phrases.
      */
     override fun createRandomMnemonics(): Array<String> {
-        return Mnemonic.createRandomMnemonics().toTypedArray()
+        return MnemonicHelper.createRandomMnemonics().toTypedArray()
     }
 
     /**
@@ -52,7 +52,7 @@ class ApolloImpl : Apollo {
      */
     @Throws(MnemonicLengthException::class)
     override fun createSeed(mnemonics: Array<String>, passphrase: String): Seed {
-        return Seed(Mnemonic.createSeed(mnemonics.asList(), passphrase))
+        return Seed(MnemonicHelper.createSeed(mnemonics.asList(), passphrase))
     }
 
     /**
@@ -66,7 +66,7 @@ class ApolloImpl : Apollo {
         return SeedWords(
             mnemonics,
             Seed(
-                value = Mnemonic.createSeed(
+                value = MnemonicHelper.createSeed(
                     mnemonics = mnemonics.asList(),
                     passphrase = passphrase ?: ""
                 )

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/apollo/ApolloTests.kt
@@ -2,7 +2,6 @@ package io.iohk.atala.prism.walletsdk.apollo
 
 import io.iohk.atala.prism.apollo.base64.base64UrlEncoded
 import io.iohk.atala.prism.apollo.derivation.DerivationPath
-import io.iohk.atala.prism.apollo.derivation.Mnemonic
 import io.iohk.atala.prism.apollo.derivation.MnemonicHelper
 import io.iohk.atala.prism.apollo.utils.ECConfig
 import io.iohk.atala.prism.walletsdk.apollo.derivation.bip39Vectors
@@ -87,7 +86,7 @@ class ApolloTests {
 
     @Test
     fun testKeyPairGeneration() {
-        keyPair = Secp256k1KeyPair.generateKeyPair(Seed(Mnemonic.createRandomSeed()), KeyCurve(Curve.SECP256K1))
+        keyPair = Secp256k1KeyPair.generateKeyPair(Seed(MnemonicHelper.createRandomSeed()), KeyCurve(Curve.SECP256K1))
         assertEquals(keyPair.publicKey.raw.size, ECConfig.PUBLIC_KEY_BYTE_SIZE)
         assertEquals(keyPair.privateKey.raw.size, ECConfig.PRIVATE_KEY_BYTE_SIZE)
     }
@@ -95,7 +94,7 @@ class ApolloTests {
     @Test
     fun testSignAndVerifyTest() {
         val message = "The quick brown fox jumps over the lazy dog"
-        keyPair = Secp256k1KeyPair.generateKeyPair(Seed(Mnemonic.createRandomSeed()), KeyCurve(Curve.SECP256K1))
+        keyPair = Secp256k1KeyPair.generateKeyPair(Seed(MnemonicHelper.createRandomSeed()), KeyCurve(Curve.SECP256K1))
         val signature = (keyPair.privateKey as Secp256k1PrivateKey).sign(message.toByteArray())
 
         assertEquals(signature.size <= ECConfig.SIGNATURE_MAX_BYTE_SIZE, true)
@@ -109,7 +108,7 @@ class ApolloTests {
     fun testDerivePrivateKey_whenSecp256k1_thenWorksAsExpected() {
         val path = "m/0'/0'/0'"
 
-        val seed = Seed(Mnemonic.createRandomSeed())
+        val seed = Seed(MnemonicHelper.createRandomSeed())
 
         val properties: MutableMap<String, Any> = mutableMapOf()
         properties[TypeKey().property] = KeyTypes.EC
@@ -175,7 +174,7 @@ class ApolloTests {
             "return",
             "height"
         )
-        val seed = Seed(Mnemonic.createSeed(mnemonics = mnemonics, passphrase = "mnemonic"))
+        val seed = Seed(MnemonicHelper.createSeed(mnemonics = mnemonics, passphrase = "mnemonic"))
 
         val expectedPrivateKeyBase64Url = "xURclKhT6as1Tb9vg4AJRRLPAMWb9dYTTthDvXEKjMc"
 
@@ -208,7 +207,7 @@ class ApolloTests {
     @Test
     fun testRestorePrivateKey_whenStorableSecp256k1_thenRestoredOk() {
         val keyPairSecp256k1 =
-            Secp256k1KeyPair.generateKeyPair(Seed(Mnemonic.createRandomSeed()), KeyCurve(Curve.SECP256K1))
+            Secp256k1KeyPair.generateKeyPair(Seed(MnemonicHelper.createRandomSeed()), KeyCurve(Curve.SECP256K1))
         val keyPairEd25519 = Ed25519KeyPair.generateKeyPair()
         val privateKeySecp256k1 = keyPairSecp256k1.privateKey as Secp256k1PrivateKey
         val privateKeyEd25519 = keyPairEd25519.privateKey as Ed25519PrivateKey
@@ -221,7 +220,7 @@ class ApolloTests {
     @Test
     fun testRestorePublicKey_whenStorableSecp256k1_thenRestoredOk() {
         val keyPairSecp256k1 =
-            Secp256k1KeyPair.generateKeyPair(Seed(Mnemonic.createRandomSeed()), KeyCurve(Curve.SECP256K1))
+            Secp256k1KeyPair.generateKeyPair(Seed(MnemonicHelper.createRandomSeed()), KeyCurve(Curve.SECP256K1))
         val keyPairEd25519 = Ed25519KeyPair.generateKeyPair()
         val publicKeySecp256k1 = keyPairSecp256k1.publicKey as Secp256k1PublicKey
         val publicKeyEd25519 = keyPairEd25519.publicKey as Ed25519PublicKey

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
@@ -2,7 +2,7 @@ package io.iohk.atala.prism.walletsdk.prismagent
 
 /* ktlint-disable import-ordering */
 import anoncreds_wrapper.LinkSecret
-import io.iohk.atala.prism.apollo.derivation.Mnemonic
+import io.iohk.atala.prism.apollo.derivation.MnemonicHelper
 import io.iohk.atala.prism.walletsdk.apollo.ApolloImpl
 import io.iohk.atala.prism.walletsdk.apollo.utils.Secp256k1KeyPair
 import io.iohk.atala.prism.walletsdk.castor.CastorImpl
@@ -72,7 +72,7 @@ class PrismAgentTests {
 
     @Test
     fun testCreateNewPrismDID_shouldCreateNewDID_whenCalled() = runTest {
-        val seed = Seed(Mnemonic.createRandomSeed())
+        val seed = Seed(MnemonicHelper.createRandomSeed())
         val validDID = DID("did", "test", "123")
         castorMock.createPrismDIDReturn = validDID
         val agent = PrismAgent(
@@ -270,7 +270,7 @@ class PrismAgentTests {
 
         val privateKeys = listOf(
             Secp256k1KeyPair.generateKeyPair(
-                seed = Seed(Mnemonic.createRandomSeed()),
+                seed = Seed(MnemonicHelper.createRandomSeed()),
                 curve = KeyCurve(Curve.SECP256K1)
             ).privateKey
         )


### PR DESCRIPTION
# Overview
We don't need to use a normal class `Mnemonic` that internally just uses `MnemonicHelper` from Apollo and I want to remove it.

Fixes #<issue number>

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
