### PR TITLE
fix: wrong casting KeyPair instead of PublicKey

### DIFF
--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/castor/CastorImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/castor/CastorImpl.kt
@@ -1,8 +1,6 @@
 package io.iohk.atala.prism.walletsdk.castor
 
-import io.iohk.atala.prism.walletsdk.apollo.utils.Ed25519KeyPair
 import io.iohk.atala.prism.walletsdk.apollo.utils.Ed25519PublicKey
-import io.iohk.atala.prism.walletsdk.apollo.utils.Secp256k1KeyPair
 import io.iohk.atala.prism.walletsdk.apollo.utils.Secp256k1PublicKey
 import io.iohk.atala.prism.walletsdk.castor.resolvers.LongFormPrismDIDResolver
 import io.iohk.atala.prism.walletsdk.castor.resolvers.PeerDIDResolver

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/castor/CastorImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/castor/CastorImpl.kt
@@ -102,7 +102,13 @@ constructor(
     override suspend fun resolveDID(did: String): DIDDocument {
         logger.debug(
             message = "Trying to resolve DID",
-            metadata = arrayOf(Metadata.MaskedMetadataByLevel(key = "DID", value = did, level = LogLevel.DEBUG))
+            metadata = arrayOf(
+                Metadata.MaskedMetadataByLevel(
+                    key = "DID",
+                    value = did,
+                    level = LogLevel.DEBUG
+                )
+            )
         )
         val resolver = CastorShared.getDIDResolver(did, resolvers)
         return resolver.resolve(did)
@@ -120,25 +126,27 @@ constructor(
      * @throws [CastorError.InvalidKeyError] if the DID or signature data are invalid.
      */
     @Throws(CastorError.InvalidKeyError::class)
-    override suspend fun verifySignature(did: DID, challenge: ByteArray, signature: ByteArray): Boolean {
+    override suspend fun verifySignature(
+        did: DID,
+        challenge: ByteArray,
+        signature: ByteArray
+    ): Boolean {
         val document = resolveDID(did.toString())
-        val keyPairs: List<PublicKey> =
+        val publicKeys: List<PublicKey> =
             CastorShared.getKeyPairFromCoreProperties(document.coreProperties)
 
-        if (keyPairs.isEmpty()) {
+        if (publicKeys.isEmpty()) {
             throw CastorError.InvalidKeyError("KeyPairs is empty")
         }
 
-        for (keyPair in keyPairs) {
-            when (keyPair.getCurve()) {
+        for (publicKey in publicKeys) {
+            when (publicKey.getCurve()) {
                 Curve.SECP256K1.value -> {
-                    val secp = keyPair as Secp256k1KeyPair
-                    return (secp.publicKey as Secp256k1PublicKey).verify(challenge, signature)
+                    return (publicKey as Secp256k1PublicKey).verify(challenge, signature)
                 }
 
                 Curve.ED25519.value -> {
-                    val ed = keyPair as Ed25519KeyPair
-                    return (ed.publicKey as Ed25519PublicKey).verify(challenge, signature)
+                    return (publicKey as Ed25519PublicKey).verify(challenge, signature)
                 }
             }
         }


### PR DESCRIPTION
# Overview
This PR fixes a cast that would never succeed, casting a public key into key pair.

Fixes #<issue number>

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [X] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [X] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [X] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
