### PR TITLE
feat: revocation notification event

### DIFF
--- a/atala-prism-sdk/src/androidInstrumentedTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/AnoncredsTests.kt
+++ b/atala-prism-sdk/src/androidInstrumentedTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/AnoncredsTests.kt
@@ -50,7 +50,7 @@ class AnoncredsTests {
         polluxMock = PolluxMock()
         mediationHandlerMock = MediationHandlerMock()
         // Pairing will be removed in the future
-        connectionManager = ConnectionManager(mercuryMock, castorMock, plutoMock, mediationHandlerMock, mutableListOf())
+        connectionManager = ConnectionManager(mercuryMock, castorMock, plutoMock, mediationHandlerMock, mutableListOf(), polluxMock)
         json = Json {
             ignoreUnknownKeys = true
             prettyPrint = true

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pluto.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pluto.kt
@@ -327,4 +327,6 @@ interface Pluto {
      * or null if no metadata is found.
      */
     fun getCredentialMetadata(linkSecretName: String): Flow<CredentialRequestMeta?>
+
+    fun revokeCredential(credentialId: String)
 }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pluto.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pluto.kt
@@ -328,5 +328,15 @@ interface Pluto {
      */
     fun getCredentialMetadata(linkSecretName: String): Flow<CredentialRequestMeta?>
 
+    /**
+     * Revokes an existing credential using the credential ID.
+     *
+     * @param credentialId The ID of the credential to be revoked
+     */
     fun revokeCredential(credentialId: String)
+
+    /**
+     * Provides a flow to listen for revoked credentials.
+     */
+    fun observeRevokedCredentials(): Flow<List<CredentialRecovery>>
 }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pollux.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/buildingblocks/Pollux.kt
@@ -97,7 +97,7 @@ interface Pollux {
      * @param credentialData The byte array containing the credential data.
      * @return The restored credential.
      */
-    fun restoreCredential(restorationIdentifier: String, credentialData: ByteArray): Credential
+    fun restoreCredential(restorationIdentifier: String, credentialData: ByteArray, revoked: Boolean): Credential
 
     /**
      * Converts a [Credential] object to a [StorableCredential] object of the specified [CredentialType].

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/models/Credential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/models/Credential.kt
@@ -11,4 +11,5 @@ interface Credential {
     val subject: String?
     val claims: Array<Claim>
     val properties: Map<String, Any?>
+    var revoked: Boolean?
 }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/models/StorableCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/domain/models/StorableCredential.kt
@@ -10,7 +10,6 @@ interface StorableCredential : Credential {
     val credentialUpdated: String?
     val credentialSchema: String?
     val validUntil: String?
-    val revoked: Boolean?
     val availableClaims: Array<String>
 
     /**

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/CredentialRecovery.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/CredentialRecovery.kt
@@ -6,4 +6,4 @@ package io.iohk.atala.prism.walletsdk.pluto
  * @property restorationId The restoration ID associated with the credential recovery.
  * @property credentialData The credential data as a byte array.
  */
-class CredentialRecovery(val restorationId: String, val credentialData: ByteArray)
+class CredentialRecovery(val restorationId: String, val credentialData: ByteArray, val revoked: Boolean)

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
@@ -1026,7 +1026,29 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
             }
     }
 
+    /**
+     * Revokes an existing credential using the credential ID.
+     *
+     * @param credentialId The ID of the credential to be revoked
+     */
     override fun revokeCredential(credentialId: String) {
         getInstance().storableCredentialQueries.revokeCredentialById(credentialId)
+    }
+
+    /**
+     * Provides a flow to listen for revoked credentials.
+     */
+    override fun observeRevokedCredentials(): Flow<List<CredentialRecovery>> {
+        return getInstance().storableCredentialQueries.observeRevokedCredential()
+            .asFlow()
+            .map {
+                it.executeAsList().map { credential ->
+                    CredentialRecovery(
+                        restorationId = credential.recoveryId,
+                        credentialData = credential.credentialData,
+                        revoked = true
+                    )
+                }
+            }
     }
 }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
@@ -57,7 +57,11 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
                 PrismPlutoDb.Schema.version,
                 AfterVersion(1) {
                     it.execute(null, "ALTER TABLE CredentialMetadata DROB COLUMN nonce;", 0)
-                    it.execute(null, "ALTER TABLE CredentialMetadata DROB COLUMN linkSecretBlindingData;", 0)
+                    it.execute(
+                        null,
+                        "ALTER TABLE CredentialMetadata DROB COLUMN linkSecretBlindingData;",
+                        0
+                    )
                     it.execute(null, "ALTER TABLE CredentialMetadata ADD COLUMN json TEXT;", 0)
                 }
             )
@@ -926,7 +930,8 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
                 it.executeAsList().map { credential ->
                     CredentialRecovery(
                         restorationId = credential.recoveryId,
-                        credentialData = credential.credentialData
+                        credentialData = credential.credentialData,
+                        revoked = credential.revoked != 0
                     )
                 }
             }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pluto/PlutoImpl.kt
@@ -1020,4 +1020,8 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
                 )
             }
     }
+
+    override fun revokeCredential(credentialId: String) {
+        getInstance().storableCredentialQueries.revokeCredentialById(credentialId)
+    }
 }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/PolluxImpl.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/PolluxImpl.kt
@@ -147,25 +147,29 @@ class PolluxImpl(
      */
     override fun restoreCredential(
         restorationIdentifier: String,
-        credentialData: ByteArray
+        credentialData: ByteArray,
+        revoked: Boolean
     ): Credential {
-        return when (restorationIdentifier) {
+        val cred: Credential
+        when (restorationIdentifier) {
             "jwt+credential" -> {
-                JWTCredential(credentialData.decodeToString())
+                cred = JWTCredential(credentialData.decodeToString())
             }
 
             "anon+credential" -> {
-                AnonCredential.fromStorableData(credentialData)
+                cred = AnonCredential.fromStorableData(credentialData)
             }
 
             "w3c+credential" -> {
-                Json.decodeFromString<W3CCredential>(credentialData.decodeToString())
+                cred = Json.decodeFromString<W3CCredential>(credentialData.decodeToString())
             }
 
             else -> {
                 throw PolluxError.InvalidCredentialError()
             }
         }
+        cred.revoked = revoked
+        return cred
     }
 
     /**
@@ -258,8 +262,10 @@ class PolluxImpl(
         val presentationRequest = PresentationRequest(attachmentBase64.base64.base64UrlDecoded)
         val cred = anoncreds_wrapper.Credential(credential.id)
 
-        val requestedAttributes = presentationRequest.getRequestedAttributes().toListRequestedAttribute()
-        val requestedPredicate = presentationRequest.getRequestedPredicates().toListRequestedPredicate()
+        val requestedAttributes =
+            presentationRequest.getRequestedAttributes().toListRequestedAttribute()
+        val requestedPredicate =
+            presentationRequest.getRequestedPredicates().toListRequestedPredicate()
 
         val credentialRequests = CredentialRequests(
             credential = cred,

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/AnonCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/AnonCredential.kt
@@ -78,6 +78,8 @@ data class AnonCredential(
             return properties.toMap()
         }
 
+    override var revoked: Boolean? = null
+
     /**
      * Converts the current credential object into a storable credential object.
      *
@@ -119,8 +121,7 @@ data class AnonCredential(
             override val validUntil: String?
                 get() = null
 
-            override val revoked: Boolean?
-                get() = null
+            override var revoked: Boolean? = c.revoked
 
             override val availableClaims: Array<String>
                 get() = c.claims.map { it.key }.toTypedArray()

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/JWTCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/JWTCredential.kt
@@ -77,6 +77,8 @@ data class JWTCredential(val data: String) : Credential {
             return properties.toMap()
         }
 
+    override var revoked: Boolean? = null
+
     /**
      * Converts the current instance of [JWTCredential] to a [StorableCredential].
      *
@@ -105,8 +107,7 @@ data class JWTCredential(val data: String) : Credential {
                 get() = c.jwtPayload.verifiableCredential.credentialSchema?.type
             override val validUntil: String?
                 get() = null
-            override val revoked: Boolean?
-                get() = null
+            override var revoked: Boolean? = c.revoked
             override val availableClaims: Array<String>
                 get() = c.claims.map { it.key }.toTypedArray()
 

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/W3CCredential.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/pollux/models/W3CCredential.kt
@@ -82,6 +82,8 @@ data class W3CCredential @JvmOverloads constructor(
             return properties.toMap()
         }
 
+    override var revoked: Boolean? = null
+
     /**
      * Converts the current W3CCredential object to a StorableCredential object that can be stored and retrieved from a storage system.
      *
@@ -102,8 +104,7 @@ data class W3CCredential @JvmOverloads constructor(
                 get() = c.credentialSchema?.type
             override val validUntil: String?
                 get() = null
-            override val revoked: Boolean?
-                get() = null
+            override var revoked: Boolean? = c.revoked
             override val availableClaims: Array<String>
                 get() = claims.map { it.key }.toTypedArray()
 

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
@@ -2,15 +2,23 @@
 
 package io.iohk.atala.prism.walletsdk.prismagent
 
+import io.iohk.atala.prism.apollo.base64.base64UrlDecoded
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Castor
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Mercury
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Pluto
+import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Pollux
+import io.iohk.atala.prism.walletsdk.domain.models.AttachmentBase64
+import io.iohk.atala.prism.walletsdk.domain.models.CredentialType
 import io.iohk.atala.prism.walletsdk.domain.models.DID
 import io.iohk.atala.prism.walletsdk.domain.models.DIDPair
 import io.iohk.atala.prism.walletsdk.domain.models.Message
+import io.iohk.atala.prism.walletsdk.pollux.models.JWTCredential
 import io.iohk.atala.prism.walletsdk.prismagent.connectionsmanager.ConnectionsManager
 import io.iohk.atala.prism.walletsdk.prismagent.connectionsmanager.DIDCommConnection
 import io.iohk.atala.prism.walletsdk.prismagent.mediation.MediationHandler
+import io.iohk.atala.prism.walletsdk.prismagent.protocols.ProtocolType
+import io.iohk.atala.prism.walletsdk.prismagent.protocols.issueCredential.IssueCredential
+import io.iohk.atala.prism.walletsdk.prismagent.protocols.revocation.RevocationNotification
 import java.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +44,7 @@ class ConnectionManager(
     private val pluto: Pluto,
     internal val mediationHandler: MediationHandler,
     private var pairings: MutableList<DIDPair>,
+    private val pollux: Pollux,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : ConnectionsManager, DIDCommConnection {
 
@@ -73,22 +82,23 @@ class ConnectionManager(
                     mediationHandler.listenUnreadMessages(
                         serviceEndpointUrl
                     ) { arrayMessages ->
-                        // Process the received messages
-                        val messagesIds = mutableListOf<String>()
-                        val messages = mutableListOf<Message>()
-                        arrayMessages.map { pair ->
-                            messagesIds.add(pair.first)
-                            messages.add(pair.second)
-                        }
-                        // If there are any messages, mark them as read and store them
-                        scope.launch {
-                            if (messagesIds.isNotEmpty()) {
-                                mediationHandler.registerMessagesAsRead(
-                                    messagesIds.toTypedArray()
-                                )
-                                pluto.storeMessages(messages)
-                            }
-                        }
+                        processMessages(arrayMessages)
+//                        // Process the received messages
+//                        val messagesIds = mutableListOf<String>()
+//                        val messages = mutableListOf<Message>()
+//                        arrayMessages.map { pair ->
+//                            messagesIds.add(pair.first)
+//                            messages.add(pair.second)
+//                        }
+//                        // If there are any messages, mark them as read and store them
+//                        scope.launch {
+//                            if (messagesIds.isNotEmpty()) {
+//                                mediationHandler.registerMessagesAsRead(
+//                                    messagesIds.toTypedArray()
+//                                )
+//                                pluto.storeMessages(messages)
+//                            }
+//                        }
                     }
                 }
 
@@ -97,18 +107,19 @@ class ConnectionManager(
                     while (true) {
                         // Continuously await and process new messages
                         awaitMessages().collect { array ->
-                            val messagesIds = mutableListOf<String>()
-                            val messages = mutableListOf<Message>()
-                            array.map { pair ->
-                                messagesIds.add(pair.first)
-                                messages.add(pair.second)
-                            }
-                            if (messagesIds.isNotEmpty()) {
-                                mediationHandler.registerMessagesAsRead(
-                                    messagesIds.toTypedArray()
-                                )
-                                pluto.storeMessages(messages)
-                            }
+                            processMessages(array)
+//                            val messagesIds = mutableListOf<String>()
+//                            val messages = mutableListOf<Message>()
+//                            array.map { pair ->
+//                                messagesIds.add(pair.first)
+//                                messages.add(pair.second)
+//                            }
+//                            if (messagesIds.isNotEmpty()) {
+//                                mediationHandler.registerMessagesAsRead(
+//                                    messagesIds.toTypedArray()
+//                                )
+//                                pluto.storeMessages(messages)
+//                            }
                         }
                         // Wait for the specified request interval before fetching new messages
                         delay(Duration.ofSeconds(requestInterval.toLong()).toMillis())
@@ -196,6 +207,47 @@ class ConnectionManager(
             pairings.removeAt(index)
         }
         return null
+    }
+
+    internal fun processMessages(arrayMessages: Array<Pair<String, Message>>) {
+        scope.launch {
+           val messagesIds = mutableListOf<String>()
+            val messages = mutableListOf<Message>()
+            arrayMessages.map { pair ->
+                messagesIds.add(pair.first)
+                messages.add(pair.second)
+            }
+
+            val allMessages = pluto.getAllMessages().first()
+
+            val revokedMessages = messages.filter { it.piuri == ProtocolType.PrismRevocation.value }
+            revokedMessages.forEach { msg ->
+                val revokedMessage = RevocationNotification.fromMessage(msg)
+                val threadId = revokedMessage.body.threadId
+                val matchingMessages =
+                    allMessages.filter { it.piuri == ProtocolType.DidcommIssueCredential.value && it.thid == threadId }
+                if (matchingMessages.isNotEmpty()) {
+                    matchingMessages.forEach { message ->
+                        val issueMessage = IssueCredential.fromMessage(message)
+                        if (pollux.extractCredentialFormatFromMessage(issueMessage.attachments) == CredentialType.JWT) {
+                            val attachment = issueMessage.attachments.firstOrNull()?.data as? AttachmentBase64
+                            attachment?.let {
+                                val credentialId = it.base64.base64UrlDecoded
+                                pluto.revokeCredential(credentialId)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // If there are any messages, mark them as read and store them
+            if (messagesIds.isNotEmpty()) {
+                mediationHandler.registerMessagesAsRead(
+                    messagesIds.toTypedArray()
+                )
+                pluto.storeMessages(messages)
+            }
+        }
     }
 
     /**

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
@@ -12,7 +12,6 @@ import io.iohk.atala.prism.walletsdk.domain.models.CredentialType
 import io.iohk.atala.prism.walletsdk.domain.models.DID
 import io.iohk.atala.prism.walletsdk.domain.models.DIDPair
 import io.iohk.atala.prism.walletsdk.domain.models.Message
-import io.iohk.atala.prism.walletsdk.pollux.models.JWTCredential
 import io.iohk.atala.prism.walletsdk.prismagent.connectionsmanager.ConnectionsManager
 import io.iohk.atala.prism.walletsdk.prismagent.connectionsmanager.DIDCommConnection
 import io.iohk.atala.prism.walletsdk.prismagent.mediation.MediationHandler
@@ -211,7 +210,7 @@ class ConnectionManager(
 
     internal fun processMessages(arrayMessages: Array<Pair<String, Message>>) {
         scope.launch {
-           val messagesIds = mutableListOf<String>()
+            val messagesIds = mutableListOf<String>()
             val messages = mutableListOf<Message>()
             arrayMessages.map { pair ->
                 messagesIds.add(pair.first)
@@ -230,7 +229,8 @@ class ConnectionManager(
                     matchingMessages.forEach { message ->
                         val issueMessage = IssueCredential.fromMessage(message)
                         if (pollux.extractCredentialFormatFromMessage(issueMessage.attachments) == CredentialType.JWT) {
-                            val attachment = issueMessage.attachments.firstOrNull()?.data as? AttachmentBase64
+                            val attachment =
+                                issueMessage.attachments.firstOrNull()?.data as? AttachmentBase64
                             attachment?.let {
                                 val credentialId = it.base64.base64UrlDecoded
                                 pluto.revokeCredential(credentialId)

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
@@ -82,22 +82,6 @@ class ConnectionManager(
                         serviceEndpointUrl
                     ) { arrayMessages ->
                         processMessages(arrayMessages)
-//                        // Process the received messages
-//                        val messagesIds = mutableListOf<String>()
-//                        val messages = mutableListOf<Message>()
-//                        arrayMessages.map { pair ->
-//                            messagesIds.add(pair.first)
-//                            messages.add(pair.second)
-//                        }
-//                        // If there are any messages, mark them as read and store them
-//                        scope.launch {
-//                            if (messagesIds.isNotEmpty()) {
-//                                mediationHandler.registerMessagesAsRead(
-//                                    messagesIds.toTypedArray()
-//                                )
-//                                pluto.storeMessages(messages)
-//                            }
-//                        }
                     }
                 }
 
@@ -107,18 +91,6 @@ class ConnectionManager(
                         // Continuously await and process new messages
                         awaitMessages().collect { array ->
                             processMessages(array)
-//                            val messagesIds = mutableListOf<String>()
-//                            val messages = mutableListOf<Message>()
-//                            array.map { pair ->
-//                                messagesIds.add(pair.first)
-//                                messages.add(pair.second)
-//                            }
-//                            if (messagesIds.isNotEmpty()) {
-//                                mediationHandler.registerMessagesAsRead(
-//                                    messagesIds.toTypedArray()
-//                                )
-//                                pluto.storeMessages(messages)
-//                            }
                         }
                         // Wait for the specified request interval before fetching new messages
                         delay(Duration.ofSeconds(requestInterval.toLong()).toMillis())

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
@@ -881,7 +881,7 @@ class PrismAgent {
         return pluto.getAllCredentials()
             .map { list ->
                 list.map {
-                    pollux.restoreCredential(it.restorationId, it.credentialData)
+                    pollux.restoreCredential(it.restorationId, it.credentialData, it.revoked)
                 }
             }
     }

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
@@ -222,7 +222,7 @@ class PrismAgent {
         this.logger = logger
         // Pairing will be removed in the future
         this.connectionManager =
-            ConnectionManager(mercury, castor, pluto, mediatorHandler, mutableListOf())
+            ConnectionManager(mercury, castor, pluto, mediatorHandler, mutableListOf(), pollux)
     }
 
     init {
@@ -455,7 +455,7 @@ class PrismAgent {
     fun setupMediatorHandler(mediatorHandler: MediationHandler) {
         stop()
         this.connectionManager =
-            ConnectionManager(mercury, castor, pluto, mediatorHandler, mutableListOf())
+            ConnectionManager(mercury, castor, pluto, mediatorHandler, mutableListOf(), pollux)
     }
 
     /**

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
@@ -988,6 +988,10 @@ class PrismAgent {
         )
     }
 
+    /**
+     * This method provides a channel to listen for credentials that are revoked. As long as there is an
+     * observer collecting from this flow the updates will keep happening.
+     */
     fun observeRevokedCredentials(): Flow<List<Credential>> {
         return pluto.observeRevokedCredentials()
             .map { list ->

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/ProtocolType.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/ProtocolType.kt
@@ -35,6 +35,7 @@ enum class ProtocolType(val value: String) {
     PickupStatus("https://didcomm.org/messagepickup/3.0/status"),
     PickupReceived("https://didcomm.org/messagepickup/3.0/messages-received"),
     LiveDeliveryChange("https://didcomm.org/messagepickup/3.0/live-delivery-change"),
+    PrismRevocation("https://atalaprism.io/revocation_notification/1.0/revoke"),
     None("");
 
     companion object {

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/revocation/RevocationNotification.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/revocation/RevocationNotification.kt
@@ -1,0 +1,57 @@
+package io.iohk.atala.prism.walletsdk.prismagent.protocols.revocation
+
+import io.iohk.atala.prism.walletsdk.domain.models.DID
+import io.iohk.atala.prism.walletsdk.domain.models.Message
+import io.iohk.atala.prism.walletsdk.prismagent.PrismAgentError
+import io.iohk.atala.prism.walletsdk.prismagent.protocols.ProtocolType
+import kotlinx.serialization.SerialName
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class RevocationNotification(
+    val id: String = UUID.randomUUID().toString(),
+    val body: Body,
+    val from: DID,
+    val to: DID
+) {
+    val type = ProtocolType.PrismRevocation
+
+    fun makeMessage(): Message {
+        return Message(
+            id = id,
+            piuri = type.value,
+            from = from,
+            to = to,
+            body = Json.encodeToString(body)
+        )
+    }
+
+    @Serializable
+    data class Body @JvmOverloads constructor(
+        @SerialName("issueCredentialProtocolThreadId")
+        val threadId: String,
+        val comment: String?
+    )
+
+    companion object {
+        fun fromMessage(message: Message): RevocationNotification {
+            require(
+                message.piuri == ProtocolType.PrismRevocation.value &&
+                        message.from != null &&
+                        message.to != null
+            ) {
+                throw PrismAgentError.InvalidMessageType(
+                    type = message.piuri,
+                    shouldBe = ProtocolType.PrismRevocation.value
+                )
+            }
+            return RevocationNotification(
+                body = Json.decodeFromString(message.body),
+                from = message.from,
+                to = message.to
+            )
+        }
+    }
+}

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/revocation/RevocationNotification.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/protocols/revocation/RevocationNotification.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:import-ordering")
+
 package io.iohk.atala.prism.walletsdk.prismagent.protocols.revocation
 
 import io.iohk.atala.prism.walletsdk.domain.models.DID
@@ -39,8 +41,8 @@ class RevocationNotification(
         fun fromMessage(message: Message): RevocationNotification {
             require(
                 message.piuri == ProtocolType.PrismRevocation.value &&
-                        message.from != null &&
-                        message.to != null
+                    message.from != null &&
+                    message.to != null
             ) {
                 throw PrismAgentError.InvalidMessageType(
                     type = message.piuri,

--- a/atala-prism-sdk/src/commonMain/sqldelight/io/iohk/atala/prism/walletsdk/pluto/data/StorableCredential.sq
+++ b/atala-prism-sdk/src/commonMain/sqldelight/io/iohk/atala/prism/walletsdk/pluto/data/StorableCredential.sq
@@ -23,3 +23,8 @@ SELECT StorableCredential.*, AvailableClaims.claim AS claims
 FROM StorableCredential
 LEFT JOIN AvailableClaims ON StorableCredential.id = AvailableClaims.credentialId
 GROUP BY StorableCredential.id;
+
+revokeCredentialById:
+UPDATE StorableCredential
+SET revoked = 1
+WHERE id = :id;

--- a/atala-prism-sdk/src/commonMain/sqldelight/io/iohk/atala/prism/walletsdk/pluto/data/StorableCredential.sq
+++ b/atala-prism-sdk/src/commonMain/sqldelight/io/iohk/atala/prism/walletsdk/pluto/data/StorableCredential.sq
@@ -28,3 +28,8 @@ revokeCredentialById:
 UPDATE StorableCredential
 SET revoked = 1
 WHERE id = :id;
+
+observeRevokedCredential:
+SELECT *
+FROM StorableCredential
+WHERE revoked = 1;

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/mercury/PlutoMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/mercury/PlutoMock.kt
@@ -180,4 +180,8 @@ class PlutoMock : Pluto {
     override fun getCredentialMetadata(linkSecretName: String): Flow<CredentialRequestMeta?> {
         TODO("Not yet implemented")
     }
+
+    override fun revokeCredential(credentialId: String) {
+        TODO("Not yet implemented")
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/mercury/PlutoMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/mercury/PlutoMock.kt
@@ -184,4 +184,8 @@ class PlutoMock : Pluto {
     override fun revokeCredential(credentialId: String) {
         TODO("Not yet implemented")
     }
+
+    override fun observeRevokedCredentials(): Flow<List<CredentialRecovery>> {
+        TODO("Not yet implemented")
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManagerTest.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManagerTest.kt
@@ -29,11 +29,9 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.anyList
 import org.mockito.kotlin.anyArray
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
 import kotlin.test.assertNotNull
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -179,6 +177,32 @@ class ConnectionManagerTest {
                     )
                 }
             )
+            val attachments: Array<AttachmentDescriptor> =
+                arrayOf(
+                    AttachmentDescriptor(
+                        mediaType = "application/json",
+                        format = CredentialType.JWT.type,
+                        data = AttachmentBase64(base64 = "asdfasdfasdfasdfasdfasdfasdfasdfasdf".base64UrlEncoded)
+                    )
+                )
+            val listMessages = listOf(
+                Message(
+                    piuri = ProtocolType.DidcommconnectionRequest.value,
+                    body = ""
+                ),
+                Message(
+                    piuri = ProtocolType.DidcommIssueCredential.value,
+                    thid = UUID.randomUUID().toString(),
+                    from = DID("did:peer:asdf897a6sdf"),
+                    to = DID("did:peer:f706sg678ha"),
+                    attachments = attachments,
+                    body = """{}"""
+                )
+            )
+            val messageList: Flow<List<Message>> = flow {
+                emit(listMessages)
+            }
+            `when`(plutoMock.getAllMessages()).thenReturn(messageList)
 
             connectionManager.startFetchingMessages()
             assertNotNull(connectionManager.fetchingMessagesJob)
@@ -219,15 +243,15 @@ class ConnectionManagerTest {
 
         val messages = arrayOf(
             Pair(
-                threadId, Message(
+                threadId,
+                Message(
                     piuri = ProtocolType.PrismRevocation.value,
                     from = DID("did:peer:0978aszdf7890asg"),
                     to = DID("did:peer:asdf9068asdf"),
-                    body = """{"threadId":"$threadId","comment":null}"""
+                    body = """{"issueCredentialProtocolThreadId":"$threadId","comment":null}"""
                 )
             )
         )
-
 
         connectionManager.processMessages(messages)
         val argumentCaptor = argumentCaptor<String>()

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManagerTest.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManagerTest.kt
@@ -2,15 +2,21 @@
 
 package io.iohk.atala.prism.walletsdk.prismagent
 
+import io.iohk.atala.prism.apollo.base64.base64UrlEncoded
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Castor
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Mercury
 import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Pluto
+import io.iohk.atala.prism.walletsdk.domain.buildingblocks.Pollux
+import io.iohk.atala.prism.walletsdk.domain.models.AttachmentBase64
+import io.iohk.atala.prism.walletsdk.domain.models.AttachmentDescriptor
+import io.iohk.atala.prism.walletsdk.domain.models.CredentialType
 import io.iohk.atala.prism.walletsdk.domain.models.Curve
 import io.iohk.atala.prism.walletsdk.domain.models.DID
 import io.iohk.atala.prism.walletsdk.domain.models.DIDDocument
 import io.iohk.atala.prism.walletsdk.domain.models.DIDUrl
 import io.iohk.atala.prism.walletsdk.domain.models.Message
 import io.iohk.atala.prism.walletsdk.prismagent.mediation.MediationHandler
+import io.iohk.atala.prism.walletsdk.prismagent.protocols.ProtocolType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -22,9 +28,16 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import java.util.UUID
+import kotlinx.coroutines.flow.Flow
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.anyList
+import org.mockito.kotlin.anyArray
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
 import kotlin.test.assertNotNull
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ConnectionManagerTest {
 
@@ -36,6 +49,9 @@ class ConnectionManagerTest {
 
     @Mock
     lateinit var plutoMock: Pluto
+
+    @Mock
+    lateinit var polluxMock: Pollux
 
     @Mock
     lateinit var basicMediatorHandlerMock: MediationHandler
@@ -53,6 +69,7 @@ class ConnectionManagerTest {
             pluto = plutoMock,
             mediationHandler = basicMediatorHandlerMock,
             pairings = mutableListOf(),
+            pollux = polluxMock,
             scope = CoroutineScope(testDispatcher)
         )
     }
@@ -168,4 +185,55 @@ class ConnectionManagerTest {
             verify(basicMediatorHandlerMock).pickupUnreadMessages(10)
             verify(basicMediatorHandlerMock).registerMessagesAsRead(arrayOf("1234"))
         }
+
+    @Test
+    fun testConnectionManager_whenProcessMessageRevoke_thenAllCorrect() = runTest {
+        val threadId = UUID.randomUUID().toString()
+        val attachments: Array<AttachmentDescriptor> =
+            arrayOf(
+                AttachmentDescriptor(
+                    mediaType = "application/json",
+                    format = CredentialType.JWT.type,
+                    data = AttachmentBase64(base64 = "asdfasdfasdfasdfasdfasdfasdfasdfasdf".base64UrlEncoded)
+                )
+            )
+        val listMessages = listOf(
+            Message(
+                piuri = ProtocolType.DidcommconnectionRequest.value,
+                body = ""
+            ),
+            Message(
+                piuri = ProtocolType.DidcommIssueCredential.value,
+                thid = threadId,
+                from = DID("did:peer:asdf897a6sdf"),
+                to = DID("did:peer:f706sg678ha"),
+                attachments = attachments,
+                body = """{}"""
+            )
+        )
+        val messageList: Flow<List<Message>> = flow {
+            emit(listMessages)
+        }
+        `when`(plutoMock.getAllMessages()).thenReturn(messageList)
+        `when`(polluxMock.extractCredentialFormatFromMessage(any())).thenReturn(CredentialType.JWT)
+
+        val messages = arrayOf(
+            Pair(
+                threadId, Message(
+                    piuri = ProtocolType.PrismRevocation.value,
+                    from = DID("did:peer:0978aszdf7890asg"),
+                    to = DID("did:peer:asdf9068asdf"),
+                    body = """{"threadId":"$threadId","comment":null}"""
+                )
+            )
+        )
+
+
+        connectionManager.processMessages(messages)
+        val argumentCaptor = argumentCaptor<String>()
+        verify(plutoMock).revokeCredential(argumentCaptor.capture())
+        assertEquals("asdfasdfasdfasdfasdfasdfasdfasdfasdf", argumentCaptor.firstValue)
+        verify(basicMediatorHandlerMock).registerMessagesAsRead(anyArray())
+        verify(plutoMock).storeMessages(anyList())
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PlutoMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PlutoMock.kt
@@ -238,4 +238,8 @@ class PlutoMock : Pluto {
     override fun getCredentialMetadata(linkSecretName: String): Flow<CredentialRequestMeta?> {
         return getCredentialMetadataReturn
     }
+
+    override fun revokeCredential(credentialId: String) {
+        TODO("Not yet implemented")
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PlutoMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PlutoMock.kt
@@ -242,4 +242,8 @@ class PlutoMock : Pluto {
     override fun revokeCredential(credentialId: String) {
         TODO("Not yet implemented")
     }
+
+    override fun observeRevokedCredentials(): Flow<List<CredentialRecovery>> {
+        TODO("Not yet implemented")
+    }
 }

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PolluxMock.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PolluxMock.kt
@@ -53,7 +53,7 @@ class PolluxMock : Pollux {
         TODO("Not yet implemented")
     }
 
-    override fun restoreCredential(restorationIdentifier: String, credentialData: ByteArray): Credential {
+    override fun restoreCredential(restorationIdentifier: String, credentialData: ByteArray, revoked: Boolean): Credential {
         TODO("Not yet implemented")
     }
 

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
@@ -61,7 +61,7 @@ class PrismAgentTests {
         polluxMock = PolluxMock()
         mediationHandlerMock = MediationHandlerMock()
         // Pairing will be removed in the future
-        connectionManager = ConnectionManager(mercuryMock, castorMock, plutoMock, mediationHandlerMock, mutableListOf())
+        connectionManager = ConnectionManager(mercuryMock, castorMock, plutoMock, mediationHandlerMock, mutableListOf(), polluxMock)
         json = Json {
             ignoreUnknownKeys = true
             prettyPrint = true

--- a/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
+++ b/atala-prism-sdk/src/commonTest/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgentTests.kt
@@ -357,7 +357,7 @@ class PrismAgentTests {
 
     @Test
     fun testStartPrismAgent_whenCalled_thenStatusIsRunning() = runTest {
-        val getLinkSecretReturn = flow<String> { "linkSecret" }
+        val getLinkSecretReturn = flow<String> { emit("linkSecret") }
         plutoMock.getLinkSecretReturn = getLinkSecretReturn
         val agent = PrismAgent(
             apollo = apolloMock,

--- a/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/credentials/CredentialsAdapter.kt
+++ b/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/credentials/CredentialsAdapter.kt
@@ -62,6 +62,7 @@ class CredentialsAdapter(private var data: MutableList<Credential> = mutableList
         private val type: TextView = itemView.findViewById(R.id.credential_id)
         private val issuanceDate: TextView = itemView.findViewById(R.id.credential_issuance_date)
         private val expDate: TextView = itemView.findViewById(R.id.credential_expiration_date)
+        private val revoked: TextView = itemView.findViewById(R.id.revoked)
         private val typeString: String = itemView.context.getString(R.string.credential_type)
         private val issuanceString: String = itemView.context.getString(R.string.credential_issuance)
         private val expirationString: String = itemView.context.getString(R.string.credential_expiration)
@@ -70,6 +71,9 @@ class CredentialsAdapter(private var data: MutableList<Credential> = mutableList
             when (cred::class) {
                 JWTCredential::class -> {
                     val jwt = cred as JWTCredential
+                    if (jwt.revoked != null && jwt.revoked!!) {
+                        revoked.visibility = View.VISIBLE
+                    }
                     type.text = String.format(typeString, "JWT")
                     // TODO: Check what else to display
                     jwt.jwtPayload.nbf?.let {

--- a/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/credentials/CredentialsViewModel.kt
+++ b/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/credentials/CredentialsViewModel.kt
@@ -14,7 +14,7 @@ class CredentialsViewModel(application: Application) : AndroidViewModel(applicat
 
     private var credentials: MutableLiveData<List<Credential>> = MutableLiveData()
 
-    init {
+    fun credentialsStream(): LiveData<List<Credential>> {
         viewModelScope.launch {
             Sdk.getInstance().agent.let {
                 it.getAllCredentials().collect { list ->
@@ -22,9 +22,6 @@ class CredentialsViewModel(application: Application) : AndroidViewModel(applicat
                 }
             }
         }
-    }
-
-    fun credentialsStream(): LiveData<List<Credential>> {
         return credentials
     }
 }

--- a/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/messages/MessagesFragment.kt
+++ b/sampleapp/src/main/java/io/iohk/atala/prism/sampleapp/ui/messages/MessagesFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import io.iohk.atala.prism.sampleapp.R
@@ -52,7 +53,8 @@ class MessagesFragment : Fragment() {
 
         // Set up the spinner with the options
         context?.let {
-            val adapter = CustomArrayAdapter(it, android.R.layout.simple_spinner_dropdown_item, credentials)
+            val adapter =
+                CustomArrayAdapter(it, android.R.layout.simple_spinner_dropdown_item, credentials)
             adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
             dialogBinding.spinner.adapter = adapter
 
@@ -81,6 +83,16 @@ class MessagesFragment : Fragment() {
                 viewModel.preparePresentationProof(credential, message)
             }
         }
+        viewModel.revokedCredentialsStream()
+            .observe(this.viewLifecycleOwner) { revokedCredentials ->
+                if (revokedCredentials.isNotEmpty()) {
+                    Toast.makeText(
+                        context,
+                        "Credential revoked ID: ${revokedCredentials.last().id}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
     }
 
     companion object {

--- a/sampleapp/src/main/res/layout/placeholder_credential.xml
+++ b/sampleapp/src/main/res/layout/placeholder_credential.xml
@@ -8,7 +8,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/cardview_dark_background"
+        android:background="#F1F1F1"
         android:orientation="vertical"
         android:padding="8dp">
 
@@ -30,6 +30,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp" />
+        
+        <TextView
+            android:id="@+id/revoked"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Revoked"
+            android:layout_gravity="end"
+            android:visibility="gone"
+            />
 
     </LinearLayout>
 </LinearLayout>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="mediator_did">Mediator DID:</string>
     <string name="agent_status_label">Agent status:</string>
     <string name="mediator_did_value">
-                did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cDovLzE5Mi4xNjguNjguMTAzOjgwODAiLCJyIjpbXSwiYSI6WyJkaWRjb21tL3YyIl19
+        did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vc2l0LXByaXNtLW1lZGlhdG9yLmF0YWxhcHJpc20uaW8iLCJhIjpbImRpZGNvbW0vdjIiXX19.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6IndzczovL3NpdC1wcmlzbS1tZWRpYXRvci5hdGFsYXByaXNtLmlvL3dzIiwiYSI6WyJkaWRjb21tL3YyIl19fQ
     </string>
     <string name="credentials_label">Credentials</string>
     <string name="host_label">Host:</string>


### PR DESCRIPTION
### Description: 
This PR adds support for revocation messages and a revocation mechanism to update the local db accordingly.
There is also a new method on the prism agent `observeRevokedCredentials` to get notified when a credential is revoked.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)