### PR TITLE
refactor: agent options non-breaking change

### DIFF
--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/ConnectionManager.kt
@@ -38,7 +38,7 @@ import kotlin.jvm.Throws
  * @property experimentLiveModeOptIn Flag to opt in or out of the experimental feature mediator live mode, using websockets.
  * @property pairings The mutable list of DIDPair representing the connections managed by the ConnectionManager.
  */
-class ConnectionManager(
+class ConnectionManager @JvmOverloads constructor(
     private val mercury: Mercury,
     private val castor: Castor,
     private val pluto: Pluto,

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/PrismAgent.kt
@@ -148,7 +148,7 @@ class PrismAgent {
         seed: Seed?,
         api: Api?,
         logger: PrismLogger = PrismLoggerImpl(LogComponent.PRISM_AGENT),
-        agentOptions: AgentOptions
+        agentOptions: AgentOptions = AgentOptions()
     ) {
         prismAgentScope.launch {
             flowState.emit(State.STOPPED)
@@ -202,7 +202,7 @@ class PrismAgent {
         api: Api? = null,
         mediatorHandler: MediationHandler,
         logger: PrismLogger = PrismLoggerImpl(LogComponent.PRISM_AGENT),
-        agentOptions: AgentOptions
+        agentOptions: AgentOptions = AgentOptions()
     ) {
         prismAgentScope.launch {
             flowState.emit(State.STOPPED)

--- a/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/helpers/AgentOptions.kt
+++ b/atala-prism-sdk/src/commonMain/kotlin/io/iohk/atala/prism/walletsdk/prismagent/helpers/AgentOptions.kt
@@ -1,5 +1,13 @@
 package io.iohk.atala.prism.walletsdk.prismagent.helpers
 
+/**
+ * Class that represent agent options that the SDK user can define to modify some behaviors of the SDK.
+ * @param experiments Represents the experimental features available
+ */
 data class AgentOptions(val experiments: Experiments = Experiments())
 
+/**
+ * Class to define experimental features available within the SDK.
+ * @param liveMode Flag to enable or disable the live mode to listen for messages from the mediator.
+ */
 data class Experiments(val liveMode: Boolean = false)


### PR DESCRIPTION
### Description: 
This PR makes the new addition `AgentOptions` a non-breaking change my including a default constructor parameter to the prism agent. It also includes missing documentation for [PR-150](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/pull/150)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)