### PR TITLE
fix: e2e test broken after pull credential changed based on validUntil

### DIFF
--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
@@ -6,7 +6,6 @@ import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.db.AfterVersion
 import io.iohk.atala.prism.apollo.base64.base64UrlDecodedBytes
 import io.iohk.atala.prism.apollo.base64.base64UrlEncoded
-import io.ktor.util.date.getTimeMillis
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -976,19 +975,13 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
     override fun getAllCredentials(): Flow<List<CredentialRecovery>> {
         return getInstance().storableCredentialQueries.fetchAllCredentials()
             .asFlow()
-            .map {
-                it.executeAsList()
-                    .mapNotNull { credential ->
-                        // Convert timestamp in millisecond to seconds to compare with the credential timestamp
-                        if (credential.validUntil != null && credential.validUntil.toInt() > (getTimeMillis() / 1000)) {
+            .map { list ->
+                list.executeAsList()
+                    .map { credential ->
                             CredentialRecovery(
                                 restorationId = credential.recoveryId,
                                 credentialData = credential.credentialData,
-                                revoked = credential.revoked != 0
-                            )
-                        } else {
-                            null
-                        }
+                                revoked = credential.revoked != 0)
                     }.takeIf { it.isNotEmpty() } ?: emptyList()
             }
     }

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
@@ -978,10 +978,11 @@ class PlutoImpl(private val connection: DbConnection) : Pluto {
             .map { list ->
                 list.executeAsList()
                     .map { credential ->
-                            CredentialRecovery(
-                                restorationId = credential.recoveryId,
-                                credentialData = credential.credentialData,
-                                revoked = credential.revoked != 0)
+                        CredentialRecovery(
+                            restorationId = credential.recoveryId,
+                            credentialData = credential.credentialData,
+                            revoked = credential.revoked != 0
+                        )
                     }.takeIf { it.isNotEmpty() } ?: emptyList()
             }
     }


### PR DESCRIPTION
### Description: 
Revert back changes made to how credentials all pulled. That change was probably added to test UI and forgot to take back before merging.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
