### PR TITLE
test: Adding happy path validation for JWT revocation

### DIFF
--- a/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/abilities/UseWalletSdk.kt
+++ b/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/abilities/UseWalletSdk.kt
@@ -3,7 +3,6 @@ package org.hyperledger.identus.walletsdk.abilities
 import com.jayway.jsonpath.JsonPath
 import io.iohk.atala.automation.utils.Logger
 import org.hyperledger.identus.walletsdk.configuration.Environment
-
 import org.hyperledger.identus.walletsdk.workflow.EdgeAgentWorkflow
 import io.restassured.RestAssured
 import kotlinx.coroutines.CoroutineScope
@@ -52,6 +51,12 @@ class UseWalletSdk : Ability {
         fun proofOfRequestStackSize(): Question<Int> {
             return Question.about("proof of request stack").answeredBy {
                 `as`(it).context.proofRequestStack.size
+            }
+        }
+
+        fun revocationStackSize(): Question<Int> {
+            return Question.about("revocation messages stack").answeredBy {
+                `as`(it).context.revocationNotificationStack.size
             }
         }
 
@@ -129,6 +134,7 @@ class UseWalletSdk : Ability {
                         ProtocolType.DidcommOfferCredential.value -> context.credentialOfferStack.add(message)
                         ProtocolType.DidcommIssueCredential.value -> context.issuedCredentialStack.add(message)
                         ProtocolType.DidcommRequestPresentation.value -> context.proofRequestStack.add(message)
+                        ProtocolType.PrismRevocation.value -> context.revocationNotificationStack.add(message)
                         else -> logger.debug("other message: ${message.piuri}")
                     }
                 }
@@ -150,7 +156,8 @@ data class SdkContext(
     val sdk: EdgeAgent,
     val credentialOfferStack: MutableList<Message> = Collections.synchronizedList(mutableListOf()),
     val proofRequestStack: MutableList<Message> = Collections.synchronizedList(mutableListOf()),
-    val issuedCredentialStack: MutableList<Message> = Collections.synchronizedList(mutableListOf())
+    val issuedCredentialStack: MutableList<Message> = Collections.synchronizedList(mutableListOf()),
+    val revocationNotificationStack: MutableList<Message> = Collections.synchronizedList(mutableListOf())
 )
 
 class ActorCannotUseWalletSdk(actor: Actor) :

--- a/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/steps/CloudAgentSteps.kt
+++ b/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/steps/CloudAgentSteps.kt
@@ -39,7 +39,7 @@ class CloudAgentSteps {
 
     @When("{actor} offers a credential")
     fun `Cloud Agent offers a credential`(cloudAgent: Actor) {
-        cloudAgentWorkflow.offerCredential(cloudAgent)
+        cloudAgentWorkflow.offerJwtCredential(cloudAgent)
     }
 
     @When("{actor} offers an anonymous credential")
@@ -61,6 +61,11 @@ class CloudAgentSteps {
     @When("{actor} asks for present-proof for anoncred")
     fun `Cloud Agent asks for present-proof for anoncred`(cloudAgent: Actor) {
         cloudAgentWorkflow.askForPresentProofForAnoncred(cloudAgent)
+    }
+
+    @When("{actor} revokes '{int}' credentials")
+    fun `Cloud Agent revokes {} credentials`(cloudAgent: Actor, numberOfRevokedCredentials: Int) {
+        cloudAgentWorkflow.revokeCredential(cloudAgent, numberOfRevokedCredentials)
     }
 
     @Then("{actor} should have the connection status updated to '{}'")

--- a/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/workflow/EdgeAgentWorkflow.kt
+++ b/tests/end-to-end/src/test/kotlin/org/hyperledger/identus/walletsdk/workflow/EdgeAgentWorkflow.kt
@@ -6,12 +6,15 @@ import io.iohk.atala.automation.utils.Logger
 import org.hyperledger.identus.walletsdk.abilities.UseWalletSdk
 import kotlinx.coroutines.flow.first
 import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.rest.interactions.Ensure
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.CoreMatchers.equalTo
 import org.hyperledger.identus.walletsdk.domain.models.CastorError
 import org.hyperledger.identus.walletsdk.edgeagent.protocols.issueCredential.IssueCredential
 import org.hyperledger.identus.walletsdk.edgeagent.protocols.issueCredential.OfferCredential
 import org.hyperledger.identus.walletsdk.edgeagent.protocols.outOfBand.OutOfBandInvitation
 import org.hyperledger.identus.walletsdk.edgeagent.protocols.proofOfPresentation.RequestPresentation
+import java.util.function.Consumer
 
 class EdgeAgentWorkflow {
     private val logger = Logger.get<EdgeAgentWorkflow>()
@@ -38,7 +41,8 @@ class EdgeAgentWorkflow {
             UseWalletSdk.execute {
                 val message = OfferCredential.fromMessage(it.credentialOfferStack.removeFirst())
                 val requestCredential = it.sdk.prepareRequestCredentialWithIssuer(it.sdk.createNewPrismDID(), message)
-                it.sdk.sendMessage(requestCredential.makeMessage())
+                val formattedMessage = requestCredential.makeMessage()
+                it.sdk.sendMessage(formattedMessage)
             }
         )
     }
@@ -100,6 +104,49 @@ class EdgeAgentWorkflow {
                     val issuedCredential = IssueCredential.fromMessage(issuedCredentialMessage)
                     sdkContext.sdk.processIssuedCredentialMessage(issuedCredential)
                 }
+            }
+        )
+    }
+
+    fun processSpecificIssuedCred(edgeAgent: Actor, recordId: String) {
+        edgeAgent.attemptsTo(
+            UseWalletSdk.execute { sdkContext ->
+                val issuedCredentialMessage = sdkContext.issuedCredentialStack.removeFirst()
+                val issuedCredential = IssueCredential.fromMessage(issuedCredentialMessage)
+                val credential = sdkContext.sdk.processIssuedCredentialMessage(issuedCredential)
+                edgeAgent.remember(recordId, credential.id)
+            }
+        )
+    }
+
+    fun waitForCredentialRevocationMessage(edgeAgent: Actor, numberOfRevocation: Int) {
+        edgeAgent.attemptsTo(
+            PollingWait.until(
+                UseWalletSdk.revocationStackSize(),
+                equalTo(numberOfRevocation)
+            )
+        )
+    }
+
+    fun waitUntilCredentialIsRevoked(edgeAgent: Actor, revokedRecordIdList: List<String>) {
+        val revokedIdList = revokedRecordIdList.map { recordId ->
+            edgeAgent.recall<String>(recordId)
+        }
+
+        edgeAgent.attemptsTo(
+            UseWalletSdk.execute { sdkContext ->
+                val credentials = sdkContext.sdk.getAllCredentials().first()
+                val revokedCredentials = credentials.filter { credential ->
+                    credential.revoked == true && revokedIdList.contains(credential.id)
+                }
+                edgeAgent.attemptsTo(
+                    Ensure.that(
+                        "The number of revoked credentials matches the expected number",
+                        Consumer { context ->
+                            assertThat(revokedCredentials.size).isEqualTo(revokedRecordIdList.size)
+                        }
+                    )
+                )
             }
         )
     }

--- a/tests/end-to-end/src/test/resources/features/credential/RevokeJWT.feature
+++ b/tests/end-to-end/src/test/resources/features/credential/RevokeJWT.feature
@@ -1,0 +1,10 @@
+@jwt @revocation
+Feature: Revoke JWT Credential
+  Edge Agent should be notified when Cloud Agent revokes a credential
+
+  Scenario: Revoke one verifiable credential
+    Given Cloud Agent is connected to Edge Agent
+    And Edge Agent has '1' jwt credentials issued by Cloud Agent
+    When Cloud Agent revokes '1' credentials
+    Then Edge Agent waits to receive the revocation notifications from Cloud Agent
+    And Edge Agent should see the credentials were revoked by Cloud Agent

--- a/tests/end-to-end/src/test/resources/features/present-proof/JWTPresentProof.feature
+++ b/tests/end-to-end/src/test/resources/features/present-proof/JWTPresentProof.feature
@@ -1,10 +1,10 @@
 @proof @jwt
-Feature: Respond to request proof
-  The Edge Agent should be able to respond to a proof-of-request
+Feature: Respond to request JWT proof
+  The Edge Agent should be able to respond to a JWT request-of-proof
 
   Scenario: Respond to request proof
     Given Cloud Agent is connected to Edge Agent
-    And Edge Agent has '1' credentials issued by Cloud Agent
+    And Edge Agent has '1' jwt credentials issued by Cloud Agent
     When Cloud Agent asks for present-proof
     And Edge Agent sends the present-proof
     Then Cloud Agent should see the present-proof is verified


### PR DESCRIPTION
https://input-output.atlassian.net/browse/ATL-6590

- Added test feature and implementation to cover happy case for JWT revocation
- Changed wording around "credential" to differentiate between JWT and AnonCred
- Broke down some in-line statements for easier (to me) debugging