### PR TITLE
ci: prefer GitHub Packages for anoncreds wrapper

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,15 +16,15 @@ dependencyResolutionManagement {
         maven("https://jitpack.io")
 
         maven {
-            url = uri("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
-        }
-
-        maven {
             url = uri("https://maven.pkg.github.com/LF-Decentralized-Trust-labs/aries-uniffi-wrappers")
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
             }
+        }
+
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
         }
     }
 }


### PR DESCRIPTION
## Summary
- move the aries-uniffi GitHub Packages repository ahead of JetBrains Space in dependency resolution
- keep the JetBrains Space repository available for its own artifacts after the GitHub Packages repo
- avoid CI failures when anoncreds wrapper resolution hits the JetBrains Space endpoint first

## Root cause
The failing Build and Test workflow on main tried to resolve `org.hyperledger:anoncreds_uniffi:0.2.0-wrapper.1` through the JetBrains Space repository first and received `503 Service Unavailable`. The GitHub Packages repository configured in `settings.gradle.kts` is the intended source for the wrapper artifact, so the repository order allowed an external outage to break the build.

## Testing
- inspected failing GitHub Actions job 76897078309 from run 26144411975
- verified the fix is limited to repository ordering in `settings.gradle.kts`
- did not complete a full local Gradle verification run because the local toolchain spent its time bootstrapping/configuring rather than reaching a clean dependency-insight result in-session