### PR TITLE
build: update Kotlin to 1.9.25

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.20"
+kotlin = "1.9.25"
 agp = "8.2.2"
 apollo = "1.8.8"
 didpeer = "1.1.2"
@@ -14,7 +14,7 @@ json = "2.0.1"
 protoc = "3.12.0"
 urdna = "1.3"
 
-ksp = "1.9.20-1.0.14" # pick a KSP in the 1.9.x line; adjust if needed
+ksp = "1.9.25-1.0.20"
 ktlint = "12.1.0"
 dokka = "1.9.20"
 sqldelight = "2.0.1"

--- a/tests/end-to-end/build.gradle.kts
+++ b/tests/end-to-end/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "1.9.25"
     idea
     id("com.github.ben-manes.versions") version "0.47.0"
     id("net.serenity-bdd.serenity-gradle-plugin") version "4.0.1"


### PR DESCRIPTION
## Summary
- update the main Kotlin Gradle plugin to 1.9.25
- update KSP to the matching 1.9.25-1.0.20 plugin
- align the nested end-to-end Kotlin JVM plugin with 1.9.25

## Why
Lace/React Native packaging needs the SDK to stay on the Kotlin 1.9.x line while using the latest compatible patch release. Apollo 1.8.8 is already published with Kotlin 1.9.25 compatibility, so this aligns sdk-kmp with that dependency stack.

## Validation
- ./gradlew :sdk:compileKotlinMetadata --no-configuration-cache --stacktrace
- ./gradlew :sdk:compileDebugKotlinAndroid :sdk:compileKotlinJvm --no-configuration-cache --stacktrace
- (cd tests/end-to-end && ./gradlew compileKotlin --no-configuration-cache --stacktrace)
- ./gradlew build allTests koverXmlReportRelease koverHtmlReportRelease --no-configuration-cache --stacktrace